### PR TITLE
Fix invalid signature: 0x80014

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,23 +6,23 @@
 	"engines": {
 		"node": ">=6.0.0",
 		"npm": ">=3.0.0"
-	},  
+	},
 	"license": "MPL-2.0",
 	"author": {
-	  "name": "Michel Gutierrez",
-	  "email": "michel.gutierrez@gmail.com",
-	  "url": "https://github.com/mi-g"
+		"name": "Michel Gutierrez",
+		"email": "michel.gutierrez@gmail.com",
+		"url": "https://github.com/mi-g"
 	},
 	"bin": {
 		"faauv": "bin/faauv.js"
 	},
 	"repository": {
-	  "type": "git",
-	  "url": "https://github.com/mi-g/firefox-addons-add-update-version.git"
+		"type": "git",
+		"url": "https://github.com/mi-g/firefox-addons-add-update-version.git"
 	},
 	"dependencies": {
 		"mozilla-version-comparator": "^1.0.2",
-		"unzip": "^0.1.11",
-		"yargs": "^10.0.3"
+		"unzip2": "^0.2.5",
+		"yargs": "^13.2.2"
 	}
 }

--- a/updater.js
+++ b/updater.js
@@ -12,7 +12,7 @@
 
 const fs = require('fs');
 const argv = require('yargs').argv;
-const unzip = require('unzip');
+const unzip = require('unzip2');
 const crypto = require('crypto');
 const compver = require('mozilla-version-comparator');
 


### PR DESCRIPTION
I was unable to sign this bundle due to ` invalid signature: 0x80014`:

- https://github.com/ipfs-shipyard/ipfs-companion/releases/download/v2.8.0.770/ipfs_companion_beta_build-2.8.0.770-an+fx.xpi

Turns out unzip is abandoned and `invalid signature: 0x80014` is known error fixed in unzip2
This PR is switching to `unzip2` and solving mentioned error.

Ref. 
- https://github.com/EvanOxfeld/node-unzip/issues/89
- https://github.com/exceljs/exceljs/issues/28

cc @mi-g 